### PR TITLE
refactor(either,maybe): change argument order to enhance composition

### DIFF
--- a/adt/deno.jsonc
+++ b/adt/deno.jsonc
@@ -1,6 +1,6 @@
 {
   "name": "@gimme/adt",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "license": "MIT",
   "exports": {
     ".": "./mod.ts",

--- a/adt/either_test.ts
+++ b/adt/either_test.ts
@@ -215,37 +215,33 @@ Deno.test("fromNullable: Right when value is not null or undefined", () => {
 });
 
 Deno.test("fromPredicate: Right when predicate is true", () => {
-  const found = fromPredicate(Array.isArray)((x) => x)(["hello", "world"]);
+  const found = fromPredicate(String)(Array.isArray)(["hello", "world"]);
   const wanted = right(["hello", "world"]);
 
   assertEquals(show(found), show(wanted));
 });
 
 Deno.test("fromPredicate: Left when predicate is false", () => {
-  const found = fromPredicate(Array.isArray)((x) => x)("hello world");
+  const found = fromPredicate(String)(Array.isArray)("hello world");
   const wanted = left("hello world");
 
   assertEquals(show(found), show(wanted));
 });
 
 Deno.test("tryCatch: Right when function does not throw", () => {
-  const found = tryCatch(
-    () => {
-      throw new Error("failure");
-    },
-    (x) => x,
-  );
+  const failingFn = () => {
+    throw new Error("failure");
+  };
+  const found = tryCatch((x) => x)(failingFn);
   const wanted = left(new Error("failure"));
   assertEquals(show(found), show(wanted));
 });
 
 Deno.test("tryCatch: Left when function does throw", () => {
-  const found = tryCatch(
-    () => {
-      return "success";
-    },
-    (x) => x,
-  );
+  const succeedingFn = () => {
+    return "success";
+  };
+  const found = tryCatch((x) => x)(succeedingFn);
   const wanted = right("success");
   assertEquals(show(found), show(wanted));
 });

--- a/adt/maybe.ts
+++ b/adt/maybe.ts
@@ -351,7 +351,7 @@ export const fromNullable = <A>(a: A): Maybe<A> =>
  * ```ts
  * import { fromPredicate } from '@gimme/adt/maybe'
  *
- * const isPositive = (n: number) => n > 0;
+ * const isPositive = (n: number): n is number => n > 0;
  * const positiveOnly = fromPredicate(isPositive);
  *
  * positiveOnly(42);    // Just(42)
@@ -360,7 +360,7 @@ export const fromNullable = <A>(a: A): Maybe<A> =>
  * ```
  */
 export const fromPredicate =
-  <A>(predicate: (a: A) => boolean) => (a: A): Maybe<A> =>
+  <A, B extends A>(predicate: (a: A) => a is B) => (a: A): Maybe<B> =>
     predicate(a) ? just(a) : nothing;
 
 /**


### PR DESCRIPTION
fromPredicate, fromNullable and tryCatch all benefit from having the "on failure" function argument first since it will allow for better composition. Especially when doing point free style composition.